### PR TITLE
Allow first house number result to be selected

### DIFF
--- a/resources/bins.js
+++ b/resources/bins.js
@@ -324,7 +324,7 @@
 	}
 
 	Bins.prototype.selectStreetNumber = function(n){
-		if(n != "") this.address.n = (typeof n==="number") ? n : parseInt(n);
+		if(n !== "") this.address.n = (typeof n==="number") ? n : parseInt(n);
 		if(typeof this.address.n==="number"){
 			this.clearResults();
 			this.getCollections(this.premises[this.address.street].numbers[this.address.n].id);


### PR DESCRIPTION
The first result from the house number drop-down n=0 would cause this if statement to return false, which then meant you were unable to select the first result.